### PR TITLE
Update Default Configuration File Path in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Two kind of events will be emitted:
 
 The embedded user interface can be customized using a single JavaScript configuration file specified in the `XK6_DASHBOARD_CONFIG` environment variable (default: `.dashboard.js` in the current directory). The configuration file is an ES6 module. The module's default export is a JavaScript function which returns a configuration object. The default configuration is passed as argument to the exported function.
 
-The default configuration is loaded from the [assets/packages/config/dist/config.json](assets/packages/config/dist/config.json) file, which can give you ideas for creating your own configuration.
+The default configuration is loaded from the [dashboard/assets/packages/config/dist/config.json](assets/packages/config/dist/config.json) file, which can give you ideas for creating your own configuration.
 
 > **Warning**
 > The format of the custom configuration has changed!


### PR DESCRIPTION
## What?

This PR updates the file path in the documentation to reflect the accurate location of the default configuration file.

## Why?

The changes are necessary to provide accurate and helpful information to users, ensuring they can locate the default configuration file successfully for customization purposes.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/xk6-dashboard/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/xk6-dashboard/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`go run mage.go lint`) and all checks pass.
- [ ] I have run tests locally (`go run mage.go test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
