### PR TITLE
[fix] Persist chart legend filters

### DIFF
--- a/dashboard/assets/packages/report/src/components/Header/Header.tsx
+++ b/dashboard/assets/packages/report/src/components/Header/Header.tsx
@@ -17,7 +17,6 @@ interface HeaderProps {
 }
 
 export function Header({ digest }: HeaderProps) {
-  console.log(digest.start, typeof digest.start)
   return (
     <Flex as="header" align="center">
       <LogoIcon />

--- a/dashboard/assets/packages/ui/src/components/Chart/Chart.hooks.ts
+++ b/dashboard/assets/packages/ui/src/components/Chart/Chart.hooks.ts
@@ -1,13 +1,19 @@
 import { useState } from "react"
-import uPlot, { type Options } from "uplot"
-import { type SeriesPlot } from "@xk6-dashboard/view"
+import uPlot, { type Options, type Series } from "uplot"
+
+import { mergeRightProps } from "utils"
 
 import { createOptions, CreateOptionsProps } from "./Chart.utils"
 
-export const useOptions = ({ plot, theme, width }: CreateOptionsProps): Options => {
-  const [series, setSeries] = useState<object | undefined>(plot.series)
+const mergeRightShowProp = mergeRightProps(["show"])
 
-  const newPlot = { ...plot, series } as SeriesPlot
+const mergeSeries = (plotSeries: Series[] = [], stateSeries: Series[] = []) => {
+  return plotSeries.map((series, i) => mergeRightShowProp(series, stateSeries[i]))
+}
+
+export const useOptions = ({ plot, theme, width }: CreateOptionsProps): Options => {
+  const [series, setSeries] = useState<Series[]>(plot.series)
+  const newPlot = { ...plot, series: mergeSeries(plot.series, series) }
   const options = createOptions({ plot: newPlot, theme, width })
   const hooks = { setSeries: [(self: uPlot) => setSeries(self.series)] }
 

--- a/dashboard/assets/packages/ui/src/components/Chart/Chart.hooks.ts
+++ b/dashboard/assets/packages/ui/src/components/Chart/Chart.hooks.ts
@@ -14,8 +14,7 @@ const mergeSeries = (plotSeries: Series[] = [], stateSeries: Series[] = []) => {
 export const useOptions = ({ plot, theme, width }: CreateOptionsProps): Options => {
   const [series, setSeries] = useState<Series[]>(plot.series)
   const newPlot = { ...plot, series: mergeSeries(plot.series, series) }
-  const options = createOptions({ plot: newPlot, theme, width })
   const hooks = { setSeries: [(self: uPlot) => setSeries(self.series)] }
 
-  return { ...options, hooks }
+  return createOptions({ hooks, plot: newPlot, theme, width })
 }

--- a/dashboard/assets/packages/ui/src/components/Chart/Chart.hooks.ts
+++ b/dashboard/assets/packages/ui/src/components/Chart/Chart.hooks.ts
@@ -1,0 +1,15 @@
+import { useState } from "react"
+import uPlot, { type Options } from "uplot"
+import { type SeriesPlot } from "@xk6-dashboard/view"
+
+import { createOptions, CreateOptionsProps } from "./Chart.utils"
+
+export const useOptions = ({ plot, theme, width }: CreateOptionsProps): Options => {
+  const [series, setSeries] = useState<object | undefined>(plot.series)
+
+  const newPlot = { ...plot, series } as SeriesPlot
+  const options = createOptions({ plot: newPlot, theme, width })
+  const hooks = { setSeries: [(self: uPlot) => setSeries(self.series)] }
+
+  return { ...options, hooks }
+}

--- a/dashboard/assets/packages/ui/src/components/Chart/Chart.hooks.ts
+++ b/dashboard/assets/packages/ui/src/components/Chart/Chart.hooks.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Raintank, Inc. dba Grafana Labs
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { useState } from "react"
 import uPlot, { type Options, type Series } from "uplot"
 

--- a/dashboard/assets/packages/ui/src/components/Chart/Chart.tsx
+++ b/dashboard/assets/packages/ui/src/components/Chart/Chart.tsx
@@ -18,7 +18,7 @@ import { Icon } from "components/Icon"
 import { Paper } from "components/Paper"
 import { Tooltip } from "components/Tooltip"
 
-import { createOptions } from "./Chart.utils"
+import { useOptions } from "./Chart.hooks"
 import * as styles from "./Chart.css"
 
 interface ChartProps {
@@ -34,7 +34,7 @@ export default function Chart({ panel, container }: ChartProps) {
   const plot = new SeriesPlot(digest, panel, createColorScheme(theme))
   const hasData = !plot.empty && plot.data[0].length > 1
   const plotData = (hasData ? plot.data : []) as AlignedData
-  const options = createOptions({ plot, theme, width })
+  const options = useOptions({ plot, theme, width })
 
   const Wrapper = container ? Fragment : Paper
 

--- a/dashboard/assets/packages/ui/src/components/Chart/Chart.utils.ts
+++ b/dashboard/assets/packages/ui/src/components/Chart/Chart.utils.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import uPlot, { type Axis, type Options, type Series } from "uplot"
+import uPlot, { type Axis, type Hooks, type Options, type Series } from "uplot"
 import { type UnitType } from "@xk6-dashboard/model"
 import { format, tooltipPlugin, SeriesPlot } from "@xk6-dashboard/view"
 
@@ -64,12 +64,13 @@ const createAxis = (colors: ReturnType<typeof createChartTheme>, length: number)
 }
 
 export interface CreateOptionsProps {
+  hooks: Hooks.Arrays
   plot: Omit<SeriesPlot, "series"> & { series: Series[] }
   theme: Theme
   width: number
 }
 
-export const createOptions = ({ plot, theme, width }: CreateOptionsProps): Options => {
+export const createOptions = ({ hooks, plot, theme, width }: CreateOptionsProps): Options => {
   const colors = createChartTheme(theme)
   const units = plot.samples.units
   const axes = units.map(createAxis(colors, units.length))
@@ -78,6 +79,7 @@ export const createOptions = ({ plot, theme, width }: CreateOptionsProps): Optio
     class: styles.uplot,
     width: width,
     height: CHART_HEIGHT,
+    hooks,
     cursor: { sync: { key: sync.key } },
     legend: { live: false },
     series: plot.series as Series[],

--- a/dashboard/assets/packages/ui/src/components/Chart/Chart.utils.ts
+++ b/dashboard/assets/packages/ui/src/components/Chart/Chart.utils.ts
@@ -4,7 +4,7 @@
 
 import uPlot, { type Axis, type Options, type Series } from "uplot"
 import { type UnitType } from "@xk6-dashboard/model"
-import { format, tooltipPlugin, type SeriesPlot } from "@xk6-dashboard/view"
+import { format, tooltipPlugin, SeriesPlot } from "@xk6-dashboard/view"
 
 import { type Theme } from "store/theme"
 import { common, grey, midnight } from "theme/colors.css"
@@ -63,7 +63,7 @@ const createAxis = (colors: ReturnType<typeof createChartTheme>, length: number)
   }
 }
 
-interface CreateOptionsProps {
+export interface CreateOptionsProps {
   plot: SeriesPlot
   theme: Theme
   width: number

--- a/dashboard/assets/packages/ui/src/components/Chart/Chart.utils.ts
+++ b/dashboard/assets/packages/ui/src/components/Chart/Chart.utils.ts
@@ -64,7 +64,7 @@ const createAxis = (colors: ReturnType<typeof createChartTheme>, length: number)
 }
 
 export interface CreateOptionsProps {
-  plot: SeriesPlot
+  plot: Omit<SeriesPlot, "series"> & { series: Series[] }
   theme: Theme
   width: number
 }

--- a/dashboard/assets/packages/ui/src/utils/object.ts
+++ b/dashboard/assets/packages/ui/src/utils/object.ts
@@ -9,6 +9,9 @@ export const omitUndefined = <T extends object>(styles: T) => {
   )
 }
 
+/**
+ * This method is used to pick the specified properties from the object
+ */
 export const pick = (props: string[], obj: object) =>
   Object.entries(obj).reduce(
     (acc, [key, value]) => {
@@ -21,6 +24,12 @@ export const pick = (props: string[], obj: object) =>
     {} as { [key: string]: unknown }
   )
 
+/**
+ * This method is used to merge two objects together. It will overwrite the values of the first object with the values
+ */
 export const mergeRight = (a: object, b: object) => ({ ...a, ...b })
 
+/**
+ * This method is used to merge two objects together. It will overwrite the values of the first object with the specified properties from the second object
+ */
 export const mergeRightProps = (props: string[]) => (a: object, b: object) => mergeRight(a, pick(props, b))

--- a/dashboard/assets/packages/ui/src/utils/object.ts
+++ b/dashboard/assets/packages/ui/src/utils/object.ts
@@ -9,7 +9,7 @@ export const omitUndefined = <T extends object>(styles: T) => {
   )
 }
 
-export const keep = (props: string[], obj: object) =>
+export const pick = (props: string[], obj: object) =>
   Object.entries(obj).reduce(
     (acc, [key, value]) => {
       if (props.includes(key)) {
@@ -23,4 +23,4 @@ export const keep = (props: string[], obj: object) =>
 
 export const mergeRight = (a: object, b: object) => ({ ...a, ...b })
 
-export const mergeRightProps = (props: string[]) => (a: object, b: object) => mergeRight(a, keep(props, b))
+export const mergeRightProps = (props: string[]) => (a: object, b: object) => mergeRight(a, pick(props, b))

--- a/dashboard/assets/packages/ui/src/utils/object.ts
+++ b/dashboard/assets/packages/ui/src/utils/object.ts
@@ -25,7 +25,7 @@ export const pick = (props: string[], obj: object) =>
   )
 
 /**
- * This method is used to merge two objects together. It will overwrite the values of the first object with the values
+ * This method is used to merge two objects together. It will overwrite the values of the first object with the values from the second object
  */
 export const mergeRight = (a: object, b: object) => ({ ...a, ...b })
 

--- a/dashboard/assets/packages/ui/src/utils/object.ts
+++ b/dashboard/assets/packages/ui/src/utils/object.ts
@@ -8,3 +8,19 @@ export const omitUndefined = <T extends object>(styles: T) => {
     {}
   )
 }
+
+export const keep = (props: string[], obj: object) =>
+  Object.entries(obj).reduce(
+    (acc, [key, value]) => {
+      if (props.includes(key)) {
+        acc[key] = value
+      }
+
+      return acc
+    },
+    {} as { [key: string]: unknown }
+  )
+
+export const mergeRight = (a: object, b: object) => ({ ...a, ...b })
+
+export const mergeRightProps = (props: string[]) => (a: object, b: object) => mergeRight(a, keep(props, b))


### PR DESCRIPTION
## What?
This PR fixes an issue where uPlot is losing it's state every render, in this case it relates to series that are being shown/hidden.

## Why?
Every time fresh data is streamed into the application it is overwriting the series data, along with their options to show/hide

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`go run mage.go lint`) and all checks pass.
- [x] I have run tests locally (`go run mage.go test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->