### PR TITLE
fix: Fixing the k6 closing issue when the browser is closed

### DIFF
--- a/dashboard/sse.go
+++ b/dashboard/sse.go
@@ -22,8 +22,6 @@ type eventEmitter struct {
 	logger  logrus.FieldLogger
 	channel string
 	wait    sync.WaitGroup
-	mu      sync.RWMutex
-	count   int
 	id      atomic.Int64
 }
 
@@ -36,30 +34,9 @@ func newEventEmitter(channel string, logger logrus.FieldLogger) *eventEmitter {
 		Server:  sse.New(),
 	}
 
-	emitter.Server.OnSubscribe = emitter.onSubscribe
-	emitter.Server.OnUnsubscribe = emitter.onUnsubscribe
-
 	emitter.CreateStream(channel)
 
 	return emitter
-}
-
-func (emitter *eventEmitter) onSubscribe(_ string, _ *sse.Subscriber) {
-	emitter.mu.Lock()
-	defer emitter.mu.Unlock()
-	emitter.count++
-	emitter.wait.Add(1)
-}
-
-func (emitter *eventEmitter) onUnsubscribe(_ string, _ *sse.Subscriber) {
-	emitter.mu.Lock()
-	defer emitter.mu.Unlock()
-
-	emitter.count--
-
-	if emitter.count >= 0 { // it seem onUnsubscribe sometimes called without onSubscribe...
-		emitter.wait.Done()
-	}
 }
 
 func (emitter *eventEmitter) onStart() error {
@@ -67,8 +44,6 @@ func (emitter *eventEmitter) onStart() error {
 }
 
 func (emitter *eventEmitter) onStop() error {
-	emitter.mu.RLock()
-	defer emitter.mu.RUnlock()
 	emitter.wait.Wait()
 
 	return nil
@@ -104,7 +79,9 @@ func (emitter *eventEmitter) ServeHTTP(res http.ResponseWriter, req *http.Reques
 
 	res.Header().Set("Access-Control-Allow-Origin", "*")
 
+	emitter.wait.Add(1)
 	emitter.Server.ServeHTTP(res, req)
+	emitter.wait.Done()
 }
 
 const maxSafeInteger = 9007199254740991


### PR DESCRIPTION
Active dashboard clients are detected based on the completion of the ServeHTTP method instead of the subscribe/unsubscribe callback of the sse library. This results in more stable operation, and it does not happen that the k6 process does not stop due to false active client detection.
