### PR TITLE
fix: corrected wait group handling in case of panic

### DIFF
--- a/dashboard/sse.go
+++ b/dashboard/sse.go
@@ -80,8 +80,9 @@ func (emitter *eventEmitter) ServeHTTP(res http.ResponseWriter, req *http.Reques
 	res.Header().Set("Access-Control-Allow-Origin", "*")
 
 	emitter.wait.Add(1)
+	defer emitter.wait.Done()
+
 	emitter.Server.ServeHTTP(res, req)
-	emitter.wait.Done()
 }
 
 const maxSafeInteger = 9007199254740991


### PR DESCRIPTION
The WaitGroup Done call did not occur if the SSE lib's ServeHTTP method generated a panic. After correction, the Done call was moved to defer.