### PR TITLE
feat: Rename "report" parameter to "export"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ See [sample HTML report](screenshot/k6-dashboard-html-report.html) or try the [o
 - [Usage](#usage)
 - [Exit](#exit)
 - [Parameters](#parameters)
+- [Environment](#environment)
 - [Docker](#docker)
 - [Save report](#save-report)
 - [Events](#events)
@@ -130,9 +131,26 @@ host      | Hostname or IP address for HTTP endpoint (default: "", empty, listen
 port      | TCP port for HTTP endpoint (default: `5665`; `0` = random, `-1` = no HTTP), example: `8080`
 period    | Event emitting frequency (default: `10s`), example: `1m`
 open      | Set to `true` (or empty) to open the browser window automatically
-report    | File name to save the report (default: "", empty, the report will not be saved)
+export    | File name to save the report (default: "", empty, the report will not be saved)
 record    | File name to save the dashboard events (default: "", empty, the events will not be saved)
 tag       | Precomputed metric tag name(s) (default: "group"), can be specified more than once
+
+*The `export` parameter used to be `report`, for compatibility reasons the name `report` can still be used.*
+
+## Environment
+
+The dashboard parameters can also be specified in environment variables. The name of the environment variable belonging to the given parameter is created by converting the parameter name to uppercase and adding the `K6_WEB_DASHBOARD_` prefix.
+
+environment variable | description
+----------|------------
+K6_WEB_DASHBOARD_HOST      | Hostname or IP address for HTTP endpoint (default: "", empty, listen on all interfaces)
+K6_WEB_DASHBOARD_PORT      | TCP port for HTTP endpoint (default: `5665`; `0` = random, `-1` = no HTTP), example: `8080`
+K6_WEB_DASHBOARD_PERIOD    | Event emitting frequency (default: `10s`), example: `1m`
+K6_WEB_DASHBOARD_OPEN      | Set to `true` (or empty) to open the browser window automatically
+K6_WEB_DASHBOARD_EXPORT    | File name to save the report (default: "", empty, the report will not be saved)
+K6_WEB_DASHBOARD_RECORD    | File name to save the dashboard events (default: "", empty, the events will not be saved)
+K6_WEB_DASHBOARD_TAG       | Precomputed metric tag name(s) (default: "group"), can be specified more than once
+
 
 ## Docker
 
@@ -154,20 +172,20 @@ The dashboard will accessible on port `5665` with any web browser: http://127.0.
 
 ## Save report
 
-The test run report can be exported to a responsive self-contained HTML file. For export, the file name must be specified in the `report` parameter. If the file name ends with `.gz`, the HTML report will automatically be gzip compressed.
+The test run report can be exported to a responsive self-contained HTML file. For export, the file name must be specified in the `export` parameter. If the file name ends with `.gz`, the HTML report will automatically be gzip compressed.
 
 ```plain
-k6 run --out dashboard=report=test-report.html script.js
+k6 run --out dashboard=export=test-report.html script.js
 ```
 
 The exported HTML report file does not contain external dependencies, so it can be displayed even without an Internet connection. Graphs can be zoomed by selecting a time interval. If necessary, the report can be printed or converted to PDF format.
 
-By using the `--report` switch of the `dashboard replay` command, the report can also be generated afterwards from the previously saved JSON format result (`--out json=test-result.json`).
+By using the `--export` switch of the `dashboard replay` command, the report can also be generated afterwards from the previously saved JSON format result (`--out json=test-result.json`).
 
 The report can also be viewed and downloaded from the dashboard UI using the buttons on the "Report" tab.
 
 ```plain
-k6 dashboard replay --report test-report.html test-result.json
+k6 dashboard replay --export test-report.html test-result.json
 ```
 
 *Example HTML report*
@@ -229,7 +247,7 @@ Flags:
       --host string     Hostname or IP address for HTTP endpoint (default: '', empty, listen on all interfaces)
       --open            Open browser window automatically
       --port int        TCP port for HTTP endpoint (0=random, -1=no HTTP), example: 8080 (default 5665)
-      --report string   Report file location (default: '', no report)
+      --export string   Report file location (default: '', no report)
   -h, --help            help for replay
 ```
 

--- a/dashboard/command.go
+++ b/dashboard/command.go
@@ -22,7 +22,7 @@ const (
 	flagPort   = "port"
 	flagPeriod = "period"
 	flagOpen   = "open"
-	flagReport = "report"
+	flagExport = "export"
 	flagTags   = "tags"
 )
 
@@ -98,9 +98,9 @@ The compressed file will be automatically decompressed if the file extension is 
 	)
 	flags.BoolVar(&opts.Open, flagOpen, defaultOpen, "Open browser window automatically")
 	flags.StringVar(
-		&opts.Report,
-		flagReport,
-		defaultReport,
+		&opts.Export,
+		flagExport,
+		defaultExport,
 		"Report file location (default: '', no report)",
 	)
 
@@ -151,7 +151,7 @@ The compressed events file will be automatically decompressed if the file extens
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Port = -1
-			opts.Report = args[1]
+			opts.Export = args[1]
 
 			if err := replay(args[0], opts, assets, proc); err != nil {
 				return err

--- a/dashboard/extension.go
+++ b/dashboard/extension.go
@@ -100,7 +100,7 @@ func (ext *extension) Start() error {
 		ext.addEventListener(newRecorder(ext.options.Record, ext.proc))
 	}
 
-	brf := newReporter(ext.options.Report, ext.assets, ext.proc)
+	brf := newReporter(ext.options.Export, ext.assets, ext.proc)
 
 	ext.addEventListener(brf)
 

--- a/dashboard/options.go
+++ b/dashboard/options.go
@@ -21,7 +21,7 @@ const (
 	defaultPort   = 5665
 	defaultPeriod = time.Second * 10
 	defaultOpen   = false
-	defaultReport = ""
+	defaultExport = ""
 	defaultRecord = ""
 )
 
@@ -32,7 +32,7 @@ type options struct {
 	Host   string
 	Period time.Duration
 	Open   bool
-	Report string
+	Export string
 	Record string
 	Tags   []string
 	TagsS  string
@@ -44,7 +44,7 @@ func envopts(env map[string]string) (*options, error) {
 		Host:   defaultHost,
 		Period: defaultPeriod,
 		Open:   defaultOpen,
-		Report: defaultReport,
+		Export: defaultExport,
 		Record: defaultRecord,
 		Tags:   defaultTags(),
 		TagsS:  "",
@@ -67,8 +67,10 @@ func envopts(env map[string]string) (*options, error) {
 		opts.Host = v
 	}
 
-	if v, ok := env[envReport]; ok {
-		opts.Report = v
+	if v, ok := env[envExport]; ok {
+		opts.Export = v
+	} else if v, ok := env[envReport]; ok {
+		opts.Export = v
 	}
 
 	if v, ok := env[envRecord]; ok {
@@ -123,8 +125,10 @@ func getopts(query string, env map[string]string) (*options, error) {
 		opts.Host = v
 	}
 
-	if v := value.Get(paramReport); len(v) != 0 {
-		opts.Report = v
+	if v := value.Get(paramExport); len(v) != 0 {
+		opts.Export = v
+	} else if v := value.Get(paramReport); len(v) != 0 {
+		opts.Export = v
 	}
 
 	if v := value.Get(paramRecord); len(v) != 0 {
@@ -211,6 +215,8 @@ const (
 
 	paramReport = "report"
 	envReport   = envPrefix + "REPORT"
+	paramExport = "export"
+	envExport   = envPrefix + "EXPORT"
 
 	paramRecord = "record"
 	envRecord   = envPrefix + "RECORD"

--- a/dashboard/options_test.go
+++ b/dashboard/options_test.go
@@ -28,7 +28,7 @@ func Test_getopts_defaults(t *testing.T) {
 	assert.Equal(t, defaultPort, opts.Port)
 	assert.Equal(t, defaultPeriod, opts.Period)
 	assert.Equal(t, defaultOpen, opts.Open)
-	assert.Equal(t, defaultReport, opts.Report)
+	assert.Equal(t, defaultExport, opts.Export)
 	assert.Equal(t, defaultTags(), opts.Tags)
 
 	assert.Equal(
@@ -54,7 +54,7 @@ func Test_getopts_env(t *testing.T) {
 		envHost:   "example.com",
 		envPeriod: "1h",
 		envRecord: "results.data",
-		envReport: "report.html",
+		envExport: "report.html",
 		envTags:   "foo,bar",
 		envOpen:   "true",
 	}
@@ -68,7 +68,7 @@ func Test_getopts_env(t *testing.T) {
 	assert.Equal(t, 1, opts.Port)
 	assert.Equal(t, time.Hour, opts.Period)
 	assert.Equal(t, true, opts.Open)
-	assert.Equal(t, "report.html", opts.Report)
+	assert.Equal(t, "report.html", opts.Export)
 	assert.Equal(t, []string{"foo", "bar"}, opts.Tags)
 
 	assert.Equal(t, "http://example.com:1", opts.url())
@@ -82,13 +82,13 @@ func Test_getopts(t *testing.T) {
 		envHost:   "example.net",
 		envPeriod: "2h",
 		envRecord: "results.data",
-		envReport: "final.html",
+		envExport: "final.html",
 		envTags:   "foo,bar",
 		envOpen:   "true",
 	}
 
 	opts, err := getopts(
-		"period=1s&port=1&host=localhost&open&report=report.html&tag=foo&tag=bar",
+		"period=1s&port=1&host=localhost&open&export=report.html&tag=foo&tag=bar",
 		env,
 	)
 
@@ -96,7 +96,7 @@ func Test_getopts(t *testing.T) {
 	assert.Equal(t, time.Second, opts.Period)
 	assert.Equal(t, 1, opts.Port)
 	assert.True(t, opts.Open)
-	assert.Equal(t, "report.html", opts.Report)
+	assert.Equal(t, "report.html", opts.Export)
 	assert.Equal(t, "localhost", opts.Host)
 	assert.Equal(t, "http://localhost:1", opts.url())
 	assert.Equal(t, "localhost:1", opts.addr())

--- a/dashboard/replay.go
+++ b/dashboard/replay.go
@@ -58,7 +58,7 @@ func replay(input string, opts *options, assets *assets, proc *process) error {
 }
 
 func (rep *replayer) run() error {
-	rptr := newReporter(rep.options.Report, rep.assets, rep.proc)
+	rptr := newReporter(rep.options.Export, rep.assets, rep.proc)
 
 	rep.addEventListener(rptr)
 

--- a/dashboard/replay_test.go
+++ b/dashboard/replay_test.go
@@ -28,7 +28,7 @@ func Test_replay(t *testing.T) {
 		Host:   "127.0.0.1",
 		Period: time.Second,
 		Open:   false,
-		Report: "",
+		Export: "",
 		Tags:   nil,
 		TagsS:  "",
 	}
@@ -50,7 +50,7 @@ func Test_replay_gz(t *testing.T) {
 		Host:   "127.0.0.1",
 		Period: time.Second,
 		Open:   false,
-		Report: "",
+		Export: "",
 		Tags:   nil,
 		TagsS:  "",
 	}
@@ -70,7 +70,7 @@ func Test_replay_open(t *testing.T) { //nolint:paralleltest
 		Host:   "127.0.0.1",
 		Period: time.Second,
 		Open:   true,
-		Report: "",
+		Export: "",
 		Tags:   nil,
 		TagsS:  "",
 	}
@@ -90,7 +90,7 @@ func Test_replay_error_port_used(t *testing.T) { //nolint:paralleltest
 		Host:   "127.0.0.1",
 		Period: time.Second,
 		Open:   false,
-		Report: "",
+		Export: "",
 		Tags:   nil,
 		TagsS:  "",
 	}
@@ -101,17 +101,17 @@ func Test_replay_error_port_used(t *testing.T) { //nolint:paralleltest
 	assert.Error(t, replay("testdata/result.ndjson.gz", opts, th.assets, th.proc))
 }
 
-func Test_replay_report(t *testing.T) {
+func Test_replay_export(t *testing.T) {
 	t.Parallel()
 
-	report := filepath.Join(t.TempDir(), "report.html")
+	export := filepath.Join(t.TempDir(), "report.html")
 
 	opts := &options{
 		Port:   -1,
 		Host:   "",
 		Period: time.Second,
 		Open:   false,
-		Report: report,
+		Export: export,
 		Tags:   nil,
 		TagsS:  "",
 	}
@@ -120,7 +120,7 @@ func Test_replay_report(t *testing.T) {
 
 	assert.NoError(t, replay("testdata/result.ndjson.gz", opts, th.assets, th.proc))
 
-	st, err := th.proc.fs.Stat(report)
+	st, err := th.proc.fs.Stat(export)
 
 	assert.NoError(t, err)
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -84,7 +84,7 @@ func out(script string) string {
 	report := filepath.Join(workdir, slug(script)+"-report.html")
 	record := filepath.Join(workdir, slug(script)+"-record.ndjson.gz")
 
-	return "dashboard=report=" + report + "&record=" + record
+	return "dashboard=export=" + report + "&record=" + record
 }
 
 func jsonout(script string) string {


### PR DESCRIPTION
Parameters can also be specified in environment variables. The names of these environment variables start with the prefix K6_WEB_DASHBOARD_ and end with the name of the parameter converted to uppercase letters. Consequently, the "report" parameter could be specified in the K6_WEB_DASHBOARD_REPORT environment variable.

k6 can save the summary, the file name can be specified in the K6_SUMMARY_EXPORT environment variable.
In order to have a uniform naming of the environment variables, it is advisable to rename the "report" parameter to "export". Thus, the name of the environment variable (K6_WEB_DASHBOARD_EXPORT) will be aligned with the name K6_SUMMARY_EXPORT.