### PR TITLE
fix: remove redundant IP address from description

### DIFF
--- a/dashboard/extension.go
+++ b/dashboard/extension.go
@@ -86,7 +86,7 @@ func (ext *extension) Description() string {
 		return ext.name
 	}
 
-	return fmt.Sprintf("%s (%s) %s", ext.name, ext.options.addr(), ext.options.url())
+	return fmt.Sprintf("%s %s", ext.name, ext.options.url())
 }
 
 // SetThresholds saves thresholds provided by k6 runtime.

--- a/dashboard/extension_test.go
+++ b/dashboard/extension_test.go
@@ -35,7 +35,7 @@ func TestNewExtension(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, ext)
 
-	assert.Equal(t, "dashboard (localhost:1) http://localhost:1", ext.Description())
+	assert.Equal(t, "dashboard http://localhost:1", ext.Description())
 
 	params.ConfigArgument = "period=2"
 
@@ -179,7 +179,7 @@ func TestExtension_random_port(t *testing.T) {
 
 	assert.Equal(
 		t,
-		fmt.Sprintf("foo (%s) %s", dashboard.options.addr(), dashboard.options.url()),
+		fmt.Sprintf("foo %s", dashboard.options.url()),
 		ext.Description(),
 	)
 


### PR DESCRIPTION
The description currently redundantly contains the extension's IP address and URL. It is advisable to keep only the URL.
