### PR TITLE
fix: clean stop

### DIFF
--- a/dashboard/extension.go
+++ b/dashboard/extension.go
@@ -158,7 +158,16 @@ func (ext *extension) Stop() error {
 
 	ext.updateAndSend(nil, newMeter(ext.period, now, ext.options.Tags), stopEvent, now)
 
-	return ext.fireStop()
+	err := ext.fireStop()
+	if err != nil {
+		return err
+	}
+
+	if ext.server != nil {
+		return ext.server.stop()
+	}
+
+	return nil
 }
 
 // AddMetricSamples adds the given metric samples to the internal buffer.


### PR DESCRIPTION
During shutdown (Stop method), the web server does not stop, and a go routine of the SSE handling remains running.

Both the SSE handling and the web server must be stopped when the extension's Stop method is called.

