### PR TITLE
[fix] Update layout for report package

### DIFF
--- a/dashboard/assets/packages/config/src/config.js
+++ b/dashboard/assets/packages/config/src/config.js
@@ -53,7 +53,7 @@ export default (config, { tab }) => {
 
         serie("http_reqs[?!tags && rate]", "Request Rate")
         serie("http_req_duration[?!tags && p95]", "Request Duration p(95)")
-        serie("http_req_failed[?!tags && rate ]", "Request Failed")
+        serie("http_req_failed[?!tags && rate]", "Request Failed")
       })
     })
 

--- a/dashboard/assets/packages/report/src/components/Section/Section.utils.ts
+++ b/dashboard/assets/packages/report/src/components/Section/Section.utils.ts
@@ -7,7 +7,7 @@ import { Panel as PanelClass, SummaryTable } from "@xk6-dashboard/view"
 
 export const getColumnSizes = (panel: PanelClass, digest: Digest) => {
   if (panel.kind == "chart") {
-    return { xs: 12, lg: 6 }
+    return { xs: 12, lg: panel.fullWidth ? 12 : 6 }
   }
 
   if (panel.kind == "summary") {


### PR DESCRIPTION
Closes https://github.com/grafana/xk6-dashboard/issues/107

This PR enables full-width charts for the report package.

<img width="1475" alt="Screenshot 2024-01-12 at 10 06 05" src="https://github.com/grafana/xk6-dashboard/assets/4395376/04df8a13-d393-440d-88fc-a45fc9148c32">
