### PR TITLE
Avoiding name conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For more build options and how to use xk6, check out the [xk6 documentation]([xk
 Without parameters the dashboard will be accessible on port `5665` with any web browser: http://127.0.0.1:5665
 
 ```plain
-$ ./k6 run --out web-dashboard script.js
+$ ./k6 run --out dashboard script.js
 
           /\      |‾‾| /‾‾/   /‾‾/   
      /\  /  \     |  |/  /   /  /    
@@ -91,7 +91,7 @@ $ ./k6 run --out web-dashboard script.js
 
   execution: local
      script: script.js
-     output: web-dashboard http://127.0.0.1:5665
+     output: dashboard http://127.0.0.1:5665
 ```
 
 The k6 process waits to exit as long as there is at least one open browser window for the dashboard extension. In this way, the report can be downloaded, for example, even after the test has been completed.
@@ -103,7 +103,7 @@ In certain environments, it is not allowed that the k6 process does not exit aft
 The output extension accepts parameters in a standard query string format:
 
 ```
-k6 run --out 'web-dashboard=param1=value1&param2=value2&param3=value3'
+k6 run --out 'dashboard=param1=value1&param2=value2&param3=value3'
 ```
 
 > Note the apostrophes (`'`) around the `--out` parameter! You should use it to escape `&` characters from the shell (or use backslash before `&`).
@@ -139,7 +139,7 @@ K6_WEB_DASHBOARD_TAG       | Precomputed metric tag name(s) (default: "group"), 
 The test run report can be exported to a responsive self-contained HTML file. For export, the file name must be specified in the `export` parameter. If the file name ends with `.gz`, the HTML report will automatically be gzip compressed.
 
 ```plain
-k6 run --out web-dashboard=export=test-report.html script.js
+k6 run --out dashboard=export=test-report.html script.js
 ```
 
 The exported HTML report file does not contain external dependencies, so it can be displayed even without an Internet connection. Graphs can be zoomed by selecting a time interval. If necessary, the report can be printed or converted to PDF format.

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -93,7 +93,7 @@ func out(script string) string {
 	report := filepath.Join(workdir, slug(script)+"-report.html")
 	record := filepath.Join(workdir, slug(script)+"-record.ndjson.gz")
 
-	return "web-dashboard=export=" + report + "&record=" + record
+	return "dashboard=export=" + report + "&record=" + record
 }
 
 func jsonout(script string) string {
@@ -128,9 +128,9 @@ func Testdata() error {
 		"json="+gz,
 		filepath.Join("scripts", "test.js"),
 		"--out",
-		"web-dashboard=port=-1&period=2s&record="+strings.ReplaceAll(out, ".json", ".ndjson"),
+		"dashboard=port=-1&period=2s&record="+strings.ReplaceAll(out, ".json", ".ndjson"),
 		"--out",
-		"web-dashboard=port=-1&period=2s&record="+strings.ReplaceAll(gz, ".json", ".ndjson"),
+		"dashboard=port=-1&period=2s&record="+strings.ReplaceAll(gz, ".json", ".ndjson"),
 	)
 }
 

--- a/register.go
+++ b/register.go
@@ -12,6 +12,8 @@ import (
 	"go.k6.io/k6/output"
 )
 
+const outputName = "dashboard"
+
 func init() {
-	output.RegisterExtension(dashboard.OutputName, dashboard.New)
+	output.RegisterExtension(outputName, dashboard.New)
 }

--- a/register_test.go
+++ b/register_test.go
@@ -18,6 +18,6 @@ func TestRegister(t *testing.T) {
 	t.Parallel()
 
 	assert.Panics(t, func() {
-		output.RegisterExtension(dashboard.OutputName, dashboard.New)
+		output.RegisterExtension(outputName, dashboard.New)
 	}) // already registered
 }


### PR DESCRIPTION
Using the name "dashboard" to avoid a name conflict with the built-in web-dashboard
