### PR TITLE
feat: added scriptPath to param event

### DIFF
--- a/dashboard/extension.go
+++ b/dashboard/extension.go
@@ -231,6 +231,7 @@ type paramData struct {
 	EndOffset  time.Duration       `json:"endOffset,omitempty"`
 	Period     time.Duration       `json:"period,omitempty"`
 	Tags       []string            `json:"tags,omitempty"`
+	ScriptPath string              `json:"scriptPath,omitempty"`
 }
 
 func newParamData(params *output.Params) *paramData {
@@ -238,6 +239,10 @@ func newParamData(params *output.Params) *paramData {
 
 	for name := range params.ScriptOptions.Scenarios {
 		param.Scenarios = append(param.Scenarios, name)
+	}
+
+	if params.ScriptPath != nil {
+		param.ScriptPath = params.ScriptPath.String()
 	}
 
 	return param

--- a/dashboard/extension_test.go
+++ b/dashboard/extension_test.go
@@ -8,6 +8,7 @@ package dashboard
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -291,12 +292,19 @@ func Test_newParamData(t *testing.T) {
 	param := newParamData(params)
 
 	assert.Len(t, param.Scenarios, 2)
+	assert.Empty(t, param.ScriptPath)
 
 	params.ScriptOptions.Scenarios = nil
+
+	u, err := url.Parse("file:///tmp/script.js")
+	assert.NoError(t, err)
+
+	params.ScriptPath = u
 
 	param = newParamData(params)
 
 	assert.Len(t, param.Scenarios, 0)
+	assert.Equal(t, param.ScriptPath, "file:///tmp/script.js")
 }
 
 func Test_paramData_With(t *testing.T) {


### PR DESCRIPTION
It is advisable to display the name of the currently running test script on the dashboard. Therefore, the script name parameter must be added to the param event.