### PR TITLE
Flagging custom metrics

### DIFF
--- a/dashboard/assets/packages/model/src/Metrics.ts
+++ b/dashboard/assets/packages/model/src/Metrics.ts
@@ -39,6 +39,7 @@ export type Metric = {
   contains?: ValueType
   type?: MetricType
   thresholds?: Array<string>
+  custom?: boolean
 }
 
 export class Query {

--- a/dashboard/builtin.go
+++ b/dashboard/builtin.go
@@ -1,0 +1,125 @@
+package dashboard
+
+import (
+	"sort"
+
+	"go.k6.io/k6/metrics"
+)
+
+const (
+	// xk6-dashboard's time
+	keyTime = "time"
+
+	// from k6 metrics/builtin.go
+	keyVUsName               = metrics.VUsName
+	keyVUsMaxName            = metrics.VUsMaxName
+	keyIterationsName        = metrics.IterationsName
+	keyIterationDurationName = metrics.IterationDurationName
+	keyDroppedIterationsName = metrics.DroppedIterationsName
+
+	keyChecksName        = metrics.ChecksName
+	keyGroupDurationName = metrics.GroupDurationName
+
+	keyHTTPReqsName              = metrics.HTTPReqsName
+	keyHTTPReqFailedName         = metrics.HTTPReqFailedName
+	keyHTTPReqDurationName       = metrics.HTTPReqDurationName
+	keyHTTPReqBlockedName        = metrics.HTTPReqBlockedName
+	keyHTTPReqConnectingName     = metrics.HTTPReqConnectingName
+	keyHTTPReqTLSHandshakingName = metrics.HTTPReqTLSHandshakingName
+	keyHTTPReqSendingName        = metrics.HTTPReqSendingName
+	keyHTTPReqWaitingName        = metrics.HTTPReqWaitingName
+	keyHTTPReqReceivingName      = metrics.HTTPReqReceivingName
+
+	keyWSSessionsName         = metrics.WSSessionsName
+	keyWSMessagesSentName     = metrics.WSMessagesSentName
+	keyWSMessagesReceivedName = metrics.WSMessagesReceivedName
+	keyWSPingName             = metrics.WSPingName
+	keyWSSessionDurationName  = metrics.WSSessionDurationName
+	keyWSConnectingName       = metrics.WSConnectingName
+
+	keyGRPCReqDurationName = metrics.GRPCReqDurationName
+
+	keyDataSentName     = metrics.DataSentName
+	keyDataReceivedName = metrics.DataReceivedName
+
+	// from xk6-browser
+
+	keyfidName  = "browser_web_vital_fid"
+	keyttfbName = "browser_web_vital_ttfb"
+	keylcpName  = "browser_web_vital_lcp"
+	keyclsName  = "browser_web_vital_cls"
+	keyinpName  = "browser_web_vital_inp"
+	keyfcpName  = "browser_web_vital_fcp"
+
+	keybrowserDataSentName        = "browser_data_sent"
+	keybrowserDataReceivedName    = "browser_data_received"
+	keybrowserHTTPReqDurationName = "browser_http_req_duration"
+	keybrowserHTTPReqFailedName   = "browser_http_req_failed"
+
+	// from k6/grpc
+
+	keyGRPCStreamsName             = "grpc_streams"
+	keyGRPCStreamsMsgsReceivedName = "grpc_streams_msgs_received"
+	keyGRPCStreamsMsgsSentName     = "grpc_streams_msgs_sent"
+)
+
+var builtinNames = []string{ //nolint:gochecknoglobals
+	keyTime,
+
+	keyVUsName,
+	keyVUsMaxName,
+	keyIterationsName,
+	keyIterationDurationName,
+	keyDroppedIterationsName,
+
+	keyChecksName,
+	keyGroupDurationName,
+
+	keyHTTPReqsName,
+	keyHTTPReqFailedName,
+	keyHTTPReqDurationName,
+	keyHTTPReqBlockedName,
+	keyHTTPReqConnectingName,
+	keyHTTPReqTLSHandshakingName,
+	keyHTTPReqSendingName,
+	keyHTTPReqWaitingName,
+	keyHTTPReqReceivingName,
+
+	keyWSSessionsName,
+	keyWSMessagesSentName,
+	keyWSMessagesReceivedName,
+	keyWSPingName,
+	keyWSSessionDurationName,
+	keyWSConnectingName,
+
+	keyGRPCReqDurationName,
+
+	keyDataSentName,
+	keyDataReceivedName,
+
+	keyfidName,
+	keyttfbName,
+	keylcpName,
+	keyclsName,
+	keyinpName,
+	keyfcpName,
+
+	keybrowserDataSentName,
+	keybrowserDataReceivedName,
+	keybrowserHTTPReqDurationName,
+	keybrowserHTTPReqFailedName,
+
+	keyGRPCStreamsName,
+	keyGRPCStreamsMsgsReceivedName,
+	keyGRPCStreamsMsgsSentName,
+}
+
+func init() {
+	sort.Strings(builtinNames)
+}
+
+func isBuiltin(name string) bool {
+	idx := sort.SearchStrings(builtinNames, name)
+
+	return idx < len(builtinNames) && builtinNames[idx] == name
+}

--- a/dashboard/meter.go
+++ b/dashboard/meter.go
@@ -220,6 +220,7 @@ type metricData struct {
 	Contains   metrics.ValueType  `json:"contains,omitempty"`
 	Tainted    bool               `json:"tainted,omitempty"`
 	Thresholds []string           `json:"thresholds,omitempty"`
+	Custom     bool               `json:"custom,omitempty"`
 }
 
 func newMetricData(origin *metrics.Metric) *metricData {
@@ -228,6 +229,7 @@ func newMetricData(origin *metrics.Metric) *metricData {
 		Contains:   origin.Contains,
 		Tainted:    origin.Tainted.Bool,
 		Thresholds: thresholdsSources(origin.Thresholds),
+		Custom:     !isBuiltin(origin.Name),
 	}
 }
 


### PR DESCRIPTION
In the various metrics tables, it is advisable to display the custom metrics before the built-in metrics, because the reader is likely to be more interested. This requires marking individual metrics on the event stream. The true value of the "custom" property indicates the custom metric.