### PR TITLE
fix: Skipping HTML report file generation if there is not enough data.

### DIFF
--- a/dashboard/extension_test.go
+++ b/dashboard/extension_test.go
@@ -307,16 +307,6 @@ func TestExtension_skip_report(t *testing.T) {
 
 	assert.NoError(t, ext.Start())
 
-	time.Sleep(time.Millisecond)
-
-	go func() {
-		sample := testSample(t, "foo", metrics.Counter, 1)
-
-		ext.AddMetricSamples(testSampleContainer(t, sample).toArray())
-	}()
-
-	time.Sleep(time.Millisecond)
-
 	assert.NoError(t, ext.Stop())
 
 	_, err = osFS.Stat(file.Name() + ".gz")

--- a/dashboard/report.go
+++ b/dashboard/report.go
@@ -24,6 +24,8 @@ type reporter struct {
 	data   *reportData
 	output string
 	mu     sync.RWMutex
+
+	snapshotCount int
 }
 
 var (
@@ -48,6 +50,13 @@ func (rep *reporter) onStart() error {
 
 func (rep *reporter) onStop(_ error) error {
 	if len(rep.output) == 0 {
+		return nil
+	}
+
+	if rep.snapshotCount < 2 {
+		rep.proc.logger.Warn(
+			"The test run was short, report generation was skipped (not enough data)",
+		)
 		return nil
 	}
 
@@ -105,6 +114,12 @@ func (rep *reporter) onEvent(name string, data interface{}) {
 		}
 
 		rep.proc.logger.Error(err)
+
+		return
+	}
+
+	if name == snapshotEvent {
+		rep.snapshotCount++
 	}
 }
 


### PR DESCRIPTION
It is confusing if an empty graph appears in the HTML report if the test run was too short. It is not clear to the user why the graph is empty.

Instead, the report generation should be skipped if there is not enough data available. This happens if the test was run for less than twice the period time (20s for the default period time).

A warning log entry informs the user about skipping the report generation.

Closes #159 
