### PR TITLE
fix #185

### DIFF
--- a/dashboard/extension.go
+++ b/dashboard/extension.go
@@ -189,12 +189,12 @@ func (ext *extension) flush() {
 	samples := ext.buffer.GetBufferedSamples()
 	now := time.Now()
 
-	if !ext.noFlush.Load() { // skip the last fraction period for sanpshot (called when flusher stops)
-		ext.updateAndSend(samples, newMeter(ext.period, now, ext.options.Tags), snapshotEvent, now)
-	}
-
 	ext.updateAndSend(samples, ext.cumulative, cumulativeEvent, now)
 	ext.evaluateAndSend(ext.cumulative, now)
+
+	if !ext.noFlush.Load() { // skip the last fraction period for sanpshot (called when flusher stops)
+		ext.updateAndSend(samples, ext.cumulative.toSnapshot(ext.period, now), snapshotEvent, now)
+	}
 }
 
 func (ext *extension) updateAndSend(

--- a/dashboard/extension_test.go
+++ b/dashboard/extension_test.go
@@ -122,12 +122,12 @@ func TestExtension(t *testing.T) {
 
 	assert.True(t, strings.HasPrefix(lines[20], idPrefix))
 	assert.True(t, strings.HasPrefix(lines[21], aggregateDataPrefix))
-	assert.Equal(t, "event: snapshot", lines[22])
+	assert.Equal(t, "event: cumulative", lines[22])
 	assert.Empty(t, lines[23])
 
 	assert.True(t, strings.HasPrefix(lines[24], idPrefix))
 	assert.True(t, strings.HasPrefix(lines[25], aggregateDataPrefix))
-	assert.Equal(t, "event: cumulative", lines[26])
+	assert.Equal(t, "event: snapshot", lines[26])
 	assert.Empty(t, lines[27])
 }
 

--- a/dashboard/meter_test.go
+++ b/dashboard/meter_test.go
@@ -134,8 +134,8 @@ func Test_meter_format(t *testing.T) {
 	assert.Equal(t, 3, len(data))
 
 	assert.Equal(t, []sampleData{
-		[]float64{0, 0},
-		[]float64{0, 0},
+		[]float64{},
+		[]float64{},
 		[]float64{float64(now.UnixMilli())},
 	}, data)
 }

--- a/scripts/demo/demo-rest.js
+++ b/scripts/demo/demo-rest.js
@@ -26,6 +26,8 @@ export let options = {
   },
 };
 
+export function setup() {} // to have "setup" group, which only has metric value at the begining of the test run
+
 export default function () {
   let crocodiles, ok;
 
@@ -47,9 +49,7 @@ export default function () {
 
   group("get crocodile", () => {
     for (var i = 0; i < crocodiles.length; i++) {
-      let response = http.get(
-        http.url`https://test-api.k6.io/public/crocodiles/${crocodiles[i].id}`
-      );
+      let response = http.get(http.url`https://test-api.k6.io/public/crocodiles/${crocodiles[i].id}`);
 
       check(response, {
         "status is OK": (r) => r && r.status == 200,


### PR DESCRIPTION
Fix #185 

An empty array is placed in the place of the missing metric in the snapshot event. Since the metric event and the snapshot event use parallel arrays, the two parallel arrays cannot be allowed to slip due to a missing metric.
