### PR TITLE
Prepare v0.8.0 release

### DIFF
--- a/releases/v0.8.0.md
+++ b/releases/v0.8.0.md
@@ -1,0 +1,25 @@
+xk6-dashboard `v0.8.0` is here 🎉!
+
+This is a significant architectural release that improves the project structure and maintainability.
+
+## New Features
+
+### Frontend Assets Extraction
+
+The frontend assets (UI, report, model, view, and config packages) have been extracted to a separate repository. This change:
+
+- Reduces the main repository size by ~7,000 lines of code
+- Removes Node.js/yarn toolchain requirements for backend development
+- Enables independent versioning and release cycles for frontend and backend
+- Maintains the same user experience and functionality
+
+**Impact:** This change is transparent to end users. The extension continues to work exactly as before, with all frontend assets embedded in the binary at build time.
+
+### Improved Project Architecture
+
+- **Separation of Concerns**: Frontend and backend development can now be managed independently
+- **Simplified Development Workflow**: Backend developers no longer need Node.js tooling installed
+- **Pre-built Assets**: Frontend assets are pre-built and distributed as a Go module
+- **Better Build Process**: Streamlined build pipeline with reduced complexity
+
+**Full Changelog**: https://github.com/grafana/xk6-dashboard/compare/v0.7.14...v0.8.0


### PR DESCRIPTION
This PR prepares the v0.8.0 release.

## Release Notes

Added comprehensive release notes for v0.8.0 documenting the major architectural change of extracting frontend assets to a separate repository.

## Release Highlights

**v0.8.0** is a significant architectural release featuring:

- **Frontend Assets Extraction**: Moved ~7,000 lines of frontend code to a separate repository
- **Simplified Development**: Backend developers no longer need Node.js tooling
- **Improved Architecture**: Better separation of concerns between frontend and backend
- **No User Impact**: All functionality remains the same for end users

This release sets the foundation for more flexible and independent development of frontend and backend components.
